### PR TITLE
Fix service name for tftpd in CentOS and RHEL7

### DIFF
--- a/tftpd_hpa/map.jinja
+++ b/tftpd_hpa/map.jinja
@@ -15,7 +15,7 @@ RedHat:
   - tftp-server
   - syslinux
   root: /var/lib/tftpboot/
-  service: tftpd-hpa
+  service: tftp
 {%- endload %}
 
 {%- set server = salt['grains.filter_by'](raw_server, merge=salt['pillar.get']('tftpd_hpa:server')) %}


### PR DESCRIPTION
The service name for CentOS and RHEL 7 is wrong, it should simply be `tftp`. This fixes that problem